### PR TITLE
Move Telemetry to helpers for cleanliness

### DIFF
--- a/simgui-window.json
+++ b/simgui-window.json
@@ -41,7 +41,7 @@
     "###Joysticks": {
       "Collapsed": "0",
       "Pos": "349,627",
-      "Size": "976,278"
+      "Size": "976,272"
     },
     "###NetworkTables": {
       "Collapsed": "0",

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -16,6 +16,7 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.commands.TeleopDriveCommand;
 import frc.robot.constants.RobotMap;
 import frc.robot.constants.TunerConstants;
+import frc.robot.helpers.Telemetry;
 
 public class RobotContainer {
   /* Setting up bindings for necessary control of the swerve drive platform */

--- a/src/main/java/frc/robot/helpers/Telemetry.java
+++ b/src/main/java/frc/robot/helpers/Telemetry.java
@@ -1,4 +1,4 @@
-package frc.robot;
+package frc.robot.helpers;
 
 import com.ctre.phoenix6.SignalLogger;
 import com.ctre.phoenix6.Utils;


### PR DESCRIPTION
Minor cleanup to help make it easier to use the sample for learning. The Telemetry class is not core functionality, so don't want it confusing students.